### PR TITLE
Fix preloader localization and imports

### DIFF
--- a/language-manager.js
+++ b/language-manager.js
@@ -3,7 +3,7 @@
  * @module languageManager
  */
 
-import CONFIG from './config.js';
+import { CONFIG } from './config.js';
 import TRANSLATIONS from './translations.js';
 import { Storage } from './utils.js';
 
@@ -194,31 +194,31 @@ export class LanguageManager {
      */
     updateAllElements() {
         // Update text content
-        const textElements = document.querySelectorAll('[data-i18n]');
+        const textElements = document.querySelectorAll('[data-i18n], [data-translate]');
         textElements.forEach(element => this.updateElement(element));
 
         // Update attributes
-        const attrElements = document.querySelectorAll('[data-i18n-attr]');
+        const attrElements = document.querySelectorAll('[data-i18n-attr], [data-translate-attr]');
         attrElements.forEach(element => this.updateElementAttributes(element));
 
         // Update placeholders
-        const placeholderElements = document.querySelectorAll('[data-i18n-placeholder]');
+        const placeholderElements = document.querySelectorAll('[data-i18n-placeholder], [data-translate-placeholder]');
         placeholderElements.forEach(element => {
-            const key = element.getAttribute('data-i18n-placeholder');
+            const key = element.getAttribute('data-i18n-placeholder') || element.getAttribute('data-translate-placeholder');
             element.placeholder = this.t(key);
         });
 
         // Update titles
-        const titleElements = document.querySelectorAll('[data-i18n-title]');
+        const titleElements = document.querySelectorAll('[data-i18n-title], [data-translate-title]');
         titleElements.forEach(element => {
-            const key = element.getAttribute('data-i18n-title');
+            const key = element.getAttribute('data-i18n-title') || element.getAttribute('data-translate-title');
             element.title = this.t(key);
         });
 
         // Update aria-labels
-        const ariaElements = document.querySelectorAll('[data-i18n-aria-label]');
+        const ariaElements = document.querySelectorAll('[data-i18n-aria-label], [data-translate-aria-label]');
         ariaElements.forEach(element => {
-            const key = element.getAttribute('data-i18n-aria-label');
+            const key = element.getAttribute('data-i18n-aria-label') || element.getAttribute('data-translate-aria-label');
             element.setAttribute('aria-label', this.t(key));
         });
     }
@@ -228,7 +228,7 @@ export class LanguageManager {
      * @param {HTMLElement} element - Element to update
      */
     updateElement(element) {
-        const key = element.getAttribute('data-i18n');
+        const key = element.getAttribute('data-i18n') || element.getAttribute('data-translate');
         if (!key) return;
 
         // Check for parameters
@@ -283,7 +283,7 @@ export class LanguageManager {
      * @param {HTMLElement} element - Element to update
      */
     updateElementAttributes(element) {
-        const attrData = element.getAttribute('data-i18n-attr');
+        const attrData = element.getAttribute('data-i18n-attr') || element.getAttribute('data-translate-attr');
         if (!attrData) return;
 
         // Parse attribute data (format: "attr1:key1,attr2:key2")

--- a/preloader.js
+++ b/preloader.js
@@ -16,11 +16,11 @@ export class AdvancedPreloader {
         this.progress = 0;
         this.selectedLanguage = null;
         this.loadingSteps = [
-            { progress: 20, message: 'preparing' },
-            { progress: 40, message: 'loadingInteractive' },
-            { progress: 60, message: 'loadingAssets' },
-            { progress: 80, message: 'initializingExperience' },
-            { progress: 100, message: 'ready' }
+            { progress: 20, message: 'preloader.preparing' },
+            { progress: 40, message: 'preloader.loadingInteractive' },
+            { progress: 60, message: 'preloader.loadingAssets' },
+            { progress: 80, message: 'preloader.initializingExperience' },
+            { progress: 100, message: 'preloader.ready' }
         ];
         this.currentStep = 0;
         this.init();
@@ -446,7 +446,7 @@ export class AdvancedPreloader {
         }
         stageContainer.innerHTML = `
             <div class="language-selection">
-                <h2 class="language-title" data-translate="chooseLang">Choose Language</h2>
+                <h2 class="language-title" data-translate="preloader.selectLanguage">Choose Language</h2>
                 <div class="language-grid">
                     <button class="language-btn" data-lang="uk">
                         <span class="flag">🇺🇦</span> Українська
@@ -461,9 +461,12 @@ export class AdvancedPreloader {
                         <span class="flag">🇪🇸</span> Español
                     </button>
                 </div>
-                <button class="continue-btn" data-translate="continue">Continue</button>
+                <button class="continue-btn" data-translate="preloader.continue">Continue</button>
             </div>
         `;
+        if (window.languageManager && typeof window.languageManager.updateAllElements === 'function') {
+            window.languageManager.updateAllElements();
+        }
 
         this.bindLanguageSelection();
     }
@@ -539,9 +542,13 @@ export class AdvancedPreloader {
                 <div class="loading-progress">
                     <div class="progress-bar"></div>
                 </div>
-                <div class="loading-text" data-translate="loading">Loading...</div>
+                <div class="loading-text" data-translate="preloader.loading">Loading...</div>
             </div>
         `;
+
+        if (window.languageManager && typeof window.languageManager.updateAllElements === 'function') {
+            window.languageManager.updateAllElements();
+        }
 
         setTimeout(() => {
             const loadingStageDiv = stageContainer.querySelector('.loading-stage');
@@ -618,9 +625,9 @@ export class AdvancedPreloader {
         
         stageContainer.innerHTML = `
             <div class="welcome-stage">
-                <h1 class="welcome-title" data-translate="welcome">Welcome</h1>
-                <p class="welcome-message" data-translate="welcomeMessage">to the magical world of INNER GARDEN</p>
-                <button class="enter-btn" data-translate="enterExhibition">Enter Exhibition</button>
+                <h1 class="welcome-title" data-translate="preloader.welcome">Welcome</h1>
+                <p class="welcome-message" data-translate="preloader.welcomeMessage">to the magical world of INNER GARDEN</p>
+                <button class="enter-btn" data-translate="preloader.enterExhibition">Enter Exhibition</button>
             </div>
         `;
 

--- a/sound-manager.js
+++ b/sound-manager.js
@@ -3,7 +3,7 @@
  * @module soundManager
  */
 
-import CONFIG from './config.js';
+import { CONFIG } from './config.js';
 import { Storage } from './utils.js';
 
 /**

--- a/translations.js
+++ b/translations.js
@@ -41,6 +41,7 @@ export const TRANSLATIONS = {
         'preloader.loadingInteractive': 'Завантаження інтерактивних елементів...',
         'preloader.loadingAssets': 'Завантаження ресурсів...',
         'preloader.initializingExperience': 'Ініціалізація досвіду...',
+        'preloader.ready': 'Готово',
         'preloader.welcome': 'Ласкаво просимо',
         'preloader.welcomeMessage': 'до магічного світу INNER GARDEN',
         'preloader.enterExhibition': 'Увійти до виставки',
@@ -435,6 +436,7 @@ export const TRANSLATIONS = {
         'preloader.loadingInteractive': 'Loading interactive elements...',
         'preloader.loadingAssets': 'Loading assets...',
         'preloader.initializingExperience': 'Initializing experience...',
+        'preloader.ready': 'Ready',
         'preloader.welcome': 'Welcome',
         'preloader.welcomeMessage': 'to the magical world of INNER GARDEN',
         'preloader.enterExhibition': 'Enter Exhibition',
@@ -812,7 +814,8 @@ export const TRANSLATIONS = {
         
         'hero.title': 'Entdecken Sie Ihren inneren Garten',
         'hero.subtitle': 'Eine interaktive Reise in die Welt der Emotionen, Erinnerungen und Träume durch Marina Kaminskás Kunst',
-        
+        'preloader.ready': 'Bereit',
+
         // Additional German translations would continue...
     },
     
@@ -836,7 +839,8 @@ export const TRANSLATIONS = {
         
         'hero.title': 'Descubre Tu Jardín Interior',
         'hero.subtitle': 'Un viaje interactivo al mundo de las emociones, recuerdos y sueños a través del arte de Marina Kaminska',
-        
+        'preloader.ready': 'Listo',
+
         // Additional Spanish translations would continue...
     }
 };


### PR DESCRIPTION
## Summary
- fix config imports in language and sound managers
- support `data-translate` attributes in `language-manager`
- align preloader messages with translation keys and update translations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851f375b9908330a30766ebfa0c9c21