### PR TITLE
Fix language fallback and module initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,26 +292,6 @@
         </div>
     </div>
 
-    <script type="module">
-        // Import all modules
-        import { CONFIG } from './config.js';
-        import Utils from './utils.js'; // Без фігурних дужок {}
-        import { TRANSLATIONS } from './translations.js';
-        import { LanguageManager } from './language-manager.js';
-        import { SoundManager } from './sound-manager.js';
-        import { AdvancedCursor } from './cursor-system.js';
-        import { AdvancedPreloader } from './preloader.js';
-        import { AdvancedInteractiveWall } from './interactive-wall.js';
-        import { Virtual3DTour } from './virtual-tour.js';
-        import { PopupSystem } from './popup-system.js';
-        import { GalleryManager } from './gallery.js';
-        import { TicketManager } from './tickets.js';
-        import InnerGardenApp from './app.js';
-
-        // Initialize the app
-        console.log('Initializing INNER GARDEN...');
-        
-        // The app will auto-initialize from app.js
-    </script>
+    <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/language-manager.js
+++ b/language-manager.js
@@ -143,6 +143,11 @@ export class LanguageManager {
             translation = TRANSLATIONS[CONFIG.language.default]?.[key];
         }
 
+        // Additional fallback to English
+        if (!translation && CONFIG.language.default !== 'en') {
+            translation = TRANSLATIONS['en']?.[key];
+        }
+
         // Use fallback or key
         if (!translation) {
             translation = fallback || key;

--- a/translations.js
+++ b/translations.js
@@ -845,5 +845,9 @@ export const TRANSLATIONS = {
     }
 };
 
+// Fill missing German and Spanish keys using English as a base
+TRANSLATIONS.de = { ...TRANSLATIONS.en, ...TRANSLATIONS.de };
+TRANSLATIONS.es = { ...TRANSLATIONS.en, ...TRANSLATIONS.es };
+
 // Export default
 export default TRANSLATIONS;


### PR DESCRIPTION
## Summary
- load app logic through a module script instead of inline imports
- add English fallback for languages without full translations
- ensure German and Spanish keys inherit English entries

## Testing
- `node --check app.js`
- `node --check language-manager.js`
- `node --check translations.js`
- `curl -I http://localhost:8001/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6851fb4ca5bc8330b357abe7b37506e1